### PR TITLE
Add option to specify "sendat" for message dispatching

### DIFF
--- a/src/Esendex/DispatchService.php
+++ b/src/Esendex/DispatchService.php
@@ -66,12 +66,14 @@ class DispatchService
 
     /**
      * @param Model\DispatchMessage $message
+     * @param string $sendAt GMT date to send the message (ISO 8601 : "Y-m-d\TH:i:s\Z")
      * @return Model\ResultItem
      * @throws Exceptions\EsendexException
      */
-    public function send(Model\DispatchMessage $message)
+    public function send(Model\DispatchMessage $message, $sendAt = null)
     {
-        $xml = $this->parser->encode($message);
+        $xml = $this->parser->encode($message, $sendAt);
+
         $uri = Http\UriBuilder::serviceUri(
             self::DISPATCH_SERVICE_VERSION,
             self::DISPATCH_SERVICE,

--- a/src/Esendex/DispatchService.php
+++ b/src/Esendex/DispatchService.php
@@ -66,11 +66,11 @@ class DispatchService
 
     /**
      * @param Model\DispatchMessage $message
-     * @param string $sendAt GMT date to send the message (ISO 8601 : "Y-m-d\TH:i:s\Z")
+     * @param \DateTime $sendAt A date and time for which to schedule the message to send
      * @return Model\ResultItem
      * @throws Exceptions\EsendexException
      */
-    public function send(Model\DispatchMessage $message, $sendAt = null)
+    public function send(Model\DispatchMessage $message, \DateTime $sendAt = null)
     {
         $xml = $this->parser->encode($message, $sendAt);
 

--- a/src/Esendex/Parser/DispatchXmlParser.php
+++ b/src/Esendex/Parser/DispatchXmlParser.php
@@ -51,11 +51,11 @@ class DispatchXmlParser
     /**
      *
      * @param \Esendex\Model\DispatchMessage $message
-     * @param string $sendAt GMT date to send the message (ISO 8601 : "Y-m-d\TH:i:s\Z")
+     * @param \DateTime $sendAt A date and time for which to schedule the message
      * @return string XML content
      * @throws ArgumentException
      */
-    public function encode(\Esendex\Model\DispatchMessage $message, $sendAt = null)
+    public function encode(\Esendex\Model\DispatchMessage $message, \DateTime $sendAt = null)
     {
         if ($message->originator() != null) {
             if (ctype_digit($message->originator())) {
@@ -81,8 +81,8 @@ class DispatchXmlParser
         $doc = new \SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?><messages />", 0, false, Api::NS);
         $doc->addAttribute("xmlns", Api::NS);
         $doc->accountreference = $this->reference;
-        if ($sendAt != null && $this->validateDate($sendAt)) {
-            $doc->sendat = $sendAt;
+        if ($sendAt != null) {
+            $doc->sendat = $sendAt->format('c');
         }
         if ($message->characterSet() != null) {
             $doc->characterset = $message->characterSet();
@@ -118,27 +118,6 @@ class DispatchXmlParser
         }
 
         return $results;
-    }
-
-    /**
-     * Validate GMT date
-     * @param string $date Date to validate
-     * @return boolean <b>TRUE</b> if date validated, <b>FALSE</b> else
-     */
-    protected function validateDate($date)
-    {
-        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/', $date, $parts) == true) {
-            $time = gmmktime($parts[4], $parts[5], $parts[6], $parts[2], $parts[3], $parts[1]);
-
-            $inputTime = strtotime($date);
-            if ($inputTime === false) {
-                return false;
-            }
-
-            return $inputTime == $time;
-        } else {
-            return false;
-        }
     }
 
 }

--- a/src/Esendex/Parser/DispatchXmlParser.php
+++ b/src/Esendex/Parser/DispatchXmlParser.php
@@ -2,7 +2,7 @@
 /**
  * Copyright (c) 2013, Esendex Ltd.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of Esendex nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -48,50 +48,68 @@ class DispatchXmlParser
         $this->reference = $accountReference;
     }
 
-    public function encode(\Esendex\Model\DispatchMessage $message)
+    /**
+     *
+     * @param \Esendex\Model\DispatchMessage $message
+     * @param string $sendAt GMT date to send the message (ISO 8601 : "Y-m-d\TH:i:s\Z")
+     * @return string XML content
+     * @throws ArgumentException
+     */
+    public function encode(\Esendex\Model\DispatchMessage $message, $sendAt = null)
     {
         if ($message->originator() != null) {
             if (ctype_digit($message->originator())) {
-                if (strlen($message->originator()) > 20)
+                if (strlen($message->originator()) > 20) {
                     throw new ArgumentException("Numeric originator must be <= 20 digits");
+                }
             } else {
-                if (strlen($message->originator()) > 11)
+                if (strlen($message->originator()) > 11) {
                     throw new ArgumentException("Alphanumeric originator must <= 11 characters");
-                if (!preg_match("/^[a-zA-Z0-9\*\$\?\!\"\#\%\&_\-\,\.\s@'\+]{1,11}$/",
-                                $message->originator()))
+                }
+                if (!preg_match("/^[a-zA-Z0-9\*\$\?\!\"\#\%\&_\-\,\.\s@'\+]{1,11}$/", $message->originator())) {
                     throw new ArgumentException("Alphanumeric originator contains invalid character(s)");
+                }
             }
         }
-        if (strlen($message->recipient()) < 1)
+        if (strlen($message->recipient()) < 1) {
             throw new ArgumentException("Recipient is invalid");
-        if ($message->validityPeriod() > 72)
+        }
+        if ($message->validityPeriod() > 72) {
             throw new ArgumentException("Validity too long, must be less or equal to than 72");
+        }
 
         $doc = new \SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?><messages />", 0, false, Api::NS);
         $doc->addAttribute("xmlns", Api::NS);
         $doc->accountreference = $this->reference;
-        if ($message->characterSet() != null)
+        if ($sendAt != null && $this->validateDate($sendAt)) {
+            $doc->sendat = $sendAt;
+        }
+        if ($message->characterSet() != null) {
             $doc->characterset = $message->characterSet();
+        }
 
         $child = $doc->addChild("message");
-        if ($message->originator() != null)
+        if ($message->originator() != null) {
             $child->from = $message->originator();
-        $child->to = $message->recipient();
+        }
+        $child->to   = $message->recipient();
         $child->body = $message->body();
-		    $child->type = $message->type();
-        if ($message->validityPeriod() > 0)
+        $child->type = $message->type();
+        if ($message->validityPeriod() > 0) {
             $child->validity = $message->validityPeriod();
-        if ($message->language() != null)
+        }
+        if ($message->language() != null) {
             $child->lang = $message->language();
-
+        }
         return $doc->asXML();
     }
 
     public function parse($xml)
     {
         $headers = simplexml_load_string($xml);
-        if ($headers->getName() != "messageheaders")
+        if ($headers->getName() != "messageheaders"){
             throw new XmlException("Xml is missing <messageheaders /> root element");
+        }
 
         $results = array();
         foreach ($headers->messageheader as $header)
@@ -101,4 +119,26 @@ class DispatchXmlParser
 
         return $results;
     }
+
+    /**
+     * Validate GMT date
+     * @param string $date Date to validate
+     * @return boolean <b>TRUE</b> if date validated, <b>FALSE</b> else
+     */
+    protected function validateDate($date)
+    {
+        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/', $date, $parts) == true) {
+            $time = gmmktime($parts[4], $parts[5], $parts[6], $parts[2], $parts[3], $parts[1]);
+
+            $inputTime = strtotime($date);
+            if ($inputTime === false) {
+                return false;
+            }
+
+            return $inputTime == $time;
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/test/Esendex/DispatchServiceTest.php
+++ b/test/Esendex/DispatchServiceTest.php
@@ -111,6 +111,47 @@ class DispatchServiceTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    function sendAtSuccess()
+    {
+        $message = new Model\DispatchMessage("Another Test", "447123456789", "This is the body text", Model\Message::SmsType);
+        $sendAt = new \DateTime('2015-05-11T12:48:00', new \DateTimeZone('UTC'));
+        $request = "xml request";
+        $response = "xml response";
+        $resultItem = new \Esendex\Model\ResultItem(
+            "97d6f0b1-ca2c-4436-aa08-025aba71705c",
+            "https://api.esendex.com/v1.0/MessageHeaders/97d6f0b1-ca2c-4436-aa08-025aba71705c"
+        );
+
+        $this->parser
+            ->expects($this->once())
+            ->method("encode")
+            ->with($this->equalTo($message), $this->equalTo($sendAt))
+            ->will($this->returnValue($request));
+        $this->httpUtil
+            ->expects($this->once())
+            ->method("post")
+            ->with(
+            $this->equalTo(
+                "https://api.esendex.com/v1.0/messagedispatcher"
+            ),
+            $this->equalTo($this->authentication),
+            $this->equalTo($request)
+        )
+            ->will($this->returnValue($response));
+        $this->parser
+            ->expects($this->once())
+            ->method("parse")
+            ->with($this->equalTo($response))
+            ->will($this->returnValue(array($resultItem)));
+
+        $result = $this->service->send($message, $sendAt);
+
+        $this->assertSame($resultItem, $result);
+    }
+
+    /**
+     * @test
+     */
     function sendFailure()
     {
         $message = new Model\DispatchMessage("DispatcherTest", "447712345678", "Message Body", Model\Message::SmsType);

--- a/test/Esendex/Parser/DispatchXmlParserTest.php
+++ b/test/Esendex/Parser/DispatchXmlParserTest.php
@@ -88,6 +88,40 @@ XML;
     /**
      * @test
      */
+    function encodeMessageWithSendAt()
+    {
+        $reference = "EX123456";
+        $sendAt = new \DateTime('2015-10-31T01:02:03');
+        $message = new DispatchMessage(
+            "4412345678",
+            "4487654321",
+            "Something to say",
+            Message::SmsType,
+            24,
+            DispatchMessage::ENGLISH_LANGUAGE
+        );
+        $parser = new DispatchXmlParser($reference);
+        $doc = new \SimpleXMLElement("<?xml version=\"1.0\" encoding=\"utf-8\"?><messages />", 0, false, Api::NS);
+        $doc->addAttribute("xmlns", Api::NS);
+        $doc->addChild("accountreference", $reference);
+        $doc->addChild("sendat", "2015-10-31T01:02:03+00:00");
+        $child = $doc->addChild("message");
+        $child->addChild("from", $message->originator());
+        $child->addChild("to", $message->recipient());
+        $child->addChild("body", $message->body());
+        $child->addChild("type", Message::SmsType);
+        $child->addChild("validity", $message->validityPeriod());
+        $child->addChild("lang", $message->language());
+        $expected = $doc->asXML();
+
+        $result = $parser->encode($message, $sendAt);
+
+        $this->assertEquals($expected, $result);
+    }
+    
+    /**
+     * @test
+     */
     function encodeVoiceMessage()
     {
         $reference = "EX123456";


### PR DESCRIPTION
Adds tests missing in #8 and switches the `$sendAt` parameter to a `\DateTime`.

I'm still unsure about this being a parameter, but it seems there's no better way unless we introduce an `options` object to group up these other settings, such as the global `characterset` for example.