### PR TITLE
Update read status

### DIFF
--- a/src/Esendex/InboxService.php
+++ b/src/Esendex/InboxService.php
@@ -2,7 +2,7 @@
 /**
  * Copyright (c) 2013, Esendex Ltd.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of Esendex nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -86,7 +86,7 @@ class InboxService
         if (count($query) > 0) {
             $uri .= "?" . Http\UriBuilder::buildQuery($query);
         }
-        
+
         $data = $this->httpClient->get(
             $uri,
             $this->authentication
@@ -111,5 +111,26 @@ class InboxService
         );
 
         return $this->httpClient->delete($uri, $this->authentication) == 200;
+    }
+
+    /**
+     *
+     * @param string $messageId
+     * @param bool $read
+     * @return bool
+     */
+    function updateReadStatus($messageId, $read = true)
+    {
+        $uri = Http\UriBuilder::serviceUri(
+            self::INBOX_SERVICE_VERSION,
+            self::INBOX_SERVICE,
+            array("messages", $messageId),
+            $this->httpClient->isSecure()
+        );
+
+        $query = array("action" => $read ? "read" : "unread");
+        $uri .= "?" . Http\UriBuilder::buildQuery($query);
+
+        return $this->httpClient->put($uri, $this->authentication, null) == 200;
     }
 }

--- a/src/Esendex/InboxService.php
+++ b/src/Esendex/InboxService.php
@@ -86,7 +86,6 @@ class InboxService
         if (count($query) > 0) {
             $uri .= "?" . Http\UriBuilder::buildQuery($query);
         }
-
         $data = $this->httpClient->get(
             $uri,
             $this->authentication
@@ -114,6 +113,7 @@ class InboxService
     }
 
     /**
+     * Update the read status of an inbox message using it's messageId
      *
      * @param string $messageId
      * @param bool $read

--- a/test/Esendex/InboxServiceTest.php
+++ b/test/Esendex/InboxServiceTest.php
@@ -2,7 +2,7 @@
 /**
  * Copyright (c) 2013, Esendex Ltd.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of Esendex nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -188,5 +188,57 @@ class InboxServiceTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(404));
 
         $this->assertFalse($this->service->deleteInboxMessage($messageId));
+    }
+
+    /**
+     * @test
+     */
+    function updateInboxMessageReadStatusSuccess()
+    {
+        $messageId = uniqid();
+
+        $readParameters = array(
+            $this->equalTo(
+                "https://api.esendex.com/v1.0/inbox/messages/{$messageId}?action=read"
+            ),
+            $this->equalTo($this->authentication)
+        );
+        $unreadParameters = array(
+            $this->equalTo(
+                "https://api.esendex.com/v1.0/inbox/messages/{$messageId}?action=unread"
+            ),
+            $this->equalTo($this->authentication)
+        );
+
+        $this->httpUtil
+            ->expects($this->exactly(3))
+            ->method("put")
+            ->withConsecutive(
+                $readParameters,
+                $readParameters,
+                $unreadParameters
+            )
+            ->will($this->returnValue(200));
+
+        $this->assertTrue($this->service->updateReadStatus($messageId));
+        $this->assertTrue($this->service->updateReadStatus($messageId, true));
+        $this->assertTrue($this->service->updateReadStatus($messageId, false));
+    }
+
+    /**
+     * @test
+     */
+    function updateInboxMessageReadStatusFailure()
+    {
+        $messageId = uniqid();
+
+        $this->httpUtil
+            ->expects($this->exactly(3))
+            ->method("put")
+            ->will($this->returnValue(404));
+
+        $this->assertFalse($this->service->updateReadStatus($messageId));
+        $this->assertFalse($this->service->updateReadStatus($messageId, true));
+        $this->assertFalse($this->service->updateReadStatus($messageId, false));
     }
 }


### PR DESCRIPTION
Add support to update read status of an inbox message. It uses the REST API as described in [developper documentation](http://developers.esendex.com/APIs/REST-API/inbox#inbox-mark-read-unread).

#### How to use it
```php
$messageId = "unique-id-of-message";
$authentication = new \Esendex\Authentication\LoginAuthentication(
    "EX000000", // Your Esendex Account Reference
    "user@example.com", // Your login email address
    "password" // Your password
);
$service = new \Esendex\InboxService($authentication);
$service->updateReadStatus($messageId); // mark message as read
$service->updateReadStatus($messageId, true); // mark message as read (explicitly)
$service->updateReadStatus($messageId, false); // mark message as unread
```