### PR TITLE
Fix autoloader ESENDEX_HOME path

### DIFF
--- a/src/Esendex/AutoLoad.php
+++ b/src/Esendex/AutoLoad.php
@@ -34,7 +34,7 @@
  */
 namespace Esendex;
 
-define('ESENDEX_HOME', dirname(__FILE__));
+define('ESENDEX_HOME', dirname(dirname(__FILE__)));
 
 class AutoLoad
 {


### PR DESCRIPTION
Update ESENDEX_HOME path to point to the parent directory so that class paths resolve correctly.